### PR TITLE
Added commands to give things to all players

### DIFF
--- a/Buffs.cs
+++ b/Buffs.cs
@@ -7,8 +7,28 @@ using Stunlock.Core;
 namespace KindredCommands;
 internal class Buffs
 {
-	public static bool AddBuff(Entity User, Entity Character, PrefabGUID buffPrefab, int duration = 0, bool immortal = true)
+	public static bool TryAddBuff(Entity User, Entity Character, PrefabGUID buffPrefab, int duration = 0, bool immortal = true)
 	{
+		if (BuffUtility.HasBuff(Core.Server.EntityManager, Character, buffPrefab.ToIdentifier()))
+		{
+			return false; // todo: is there any actual use case for not updating an existing buff?
+		}
+
+		if (!TryGetOrCreateBuff(User, Character, buffPrefab, out var buffEntity))
+		{
+			return false;
+		}
+		UpdateBuff(buffEntity, duration, immortal);
+		return true;
+	}
+
+	public static bool TryGetOrCreateBuff(Entity User, Entity Character, PrefabGUID buffPrefab, out Entity buffEntity)
+	{
+		if (BuffUtility.TryGetBuff(Core.Server.EntityManager, Character, buffPrefab, out buffEntity))
+		{
+			return true;
+		}
+
 		var des = Core.Server.GetExistingSystemManaged<DebugEventsSystem>();
 		var buffEvent = new ApplyBuffDebugEvent()
 		{
@@ -19,75 +39,71 @@ internal class Buffs
 			User = User,
 			Character = Character
 		};
-		if (!BuffUtility.TryGetBuff(Core.Server.EntityManager, Character, buffPrefab, out Entity buffEntity))
-		{
-			des.ApplyBuff(fromCharacter, buffEvent);
-			if (BuffUtility.TryGetBuff(Core.Server.EntityManager, Character, buffPrefab, out buffEntity))
-			{
-				if (buffEntity.Has<CreateGameplayEventsOnSpawn>())
-				{
-					buffEntity.Remove<CreateGameplayEventsOnSpawn>();
-				}
-				if (buffEntity.Has<GameplayEventListeners>())
-				{
-					buffEntity.Remove<GameplayEventListeners>();
-				}
-
-				if (immortal)
-				{
-					buffEntity.Add<Buff_Persists_Through_Death>();
-					if (buffEntity.Has<RemoveBuffOnGameplayEvent>())
-					{
-						buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-					}
-
-					if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>())
-					{
-						buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-					}
-				}
-				if (duration > -1 && duration != 0)
-				{
-					if (!buffEntity.Has<LifeTime>())
-					{
-						buffEntity.Add<LifeTime>();
-						buffEntity.Write(new LifeTime
-						{
-							EndAction = LifeTimeEndAction.Destroy
-						});
-					}
-
-					var lifetime = buffEntity.Read<LifeTime>();
-					lifetime.Duration = duration;
-					buffEntity.Write(lifetime);
-				}
-				else if (duration == -1)
-				{
-					if (buffEntity.Has<LifeTime>())
-					{
-						var lifetime = buffEntity.Read<LifeTime>();
-						lifetime.EndAction = LifeTimeEndAction.None;
-						buffEntity.Write(lifetime);
-					}
-					if (buffEntity.Has<RemoveBuffOnGameplayEvent>())
-					{
-						buffEntity.Remove<RemoveBuffOnGameplayEvent>();
-					}
-					if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>())
-					{
-						buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
-					}
-				}
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-		else
+		des.ApplyBuff(fromCharacter, buffEvent);
+		
+		if (!BuffUtility.TryGetBuff(Core.Server.EntityManager, Character, buffPrefab, out buffEntity))
 		{
 			return false;
+		}
+
+		if (buffEntity.Has<CreateGameplayEventsOnSpawn>())
+		{
+			buffEntity.Remove<CreateGameplayEventsOnSpawn>();
+		}
+		if (buffEntity.Has<GameplayEventListeners>())
+		{
+			buffEntity.Remove<GameplayEventListeners>();
+		}
+		return true;
+	}	
+
+	public static void UpdateBuff(Entity buffEntity, int duration = 0, bool immortal = true)
+	{
+		if (immortal)
+		{
+			buffEntity.Add<Buff_Persists_Through_Death>();
+			if (buffEntity.Has<RemoveBuffOnGameplayEvent>())
+			{
+				buffEntity.Remove<RemoveBuffOnGameplayEvent>();
+			}
+
+			if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>())
+			{
+				buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+			}
+		}
+
+		if (duration > -1 && duration != 0)
+		{
+			if (!buffEntity.Has<LifeTime>())
+			{
+				buffEntity.Add<LifeTime>();
+				buffEntity.Write(new LifeTime
+				{
+					EndAction = LifeTimeEndAction.Destroy
+				});
+			}
+
+			var lifetime = buffEntity.Read<LifeTime>();
+			lifetime.Duration = duration;
+			buffEntity.Write(lifetime);
+		}
+		else if (duration == -1)
+		{
+			if (buffEntity.Has<LifeTime>())
+			{
+				var lifetime = buffEntity.Read<LifeTime>();
+				lifetime.EndAction = LifeTimeEndAction.None;
+				buffEntity.Write(lifetime);
+			}
+			if (buffEntity.Has<RemoveBuffOnGameplayEvent>())
+			{
+				buffEntity.Remove<RemoveBuffOnGameplayEvent>();
+			}
+			if (buffEntity.Has<RemoveBuffOnGameplayEventEntry>())
+			{
+				buffEntity.Remove<RemoveBuffOnGameplayEventEntry>();
+			}
 		}
 	}
 

--- a/Commands/AFKCommands.cs
+++ b/Commands/AFKCommands.cs
@@ -12,7 +12,7 @@ internal class AFKCommands
 		//"AB_Bear_FallAsleep_SleepingIdle_Buff": -883762685 - gives the ZZzzz animation and locks player in place, spells still work
 		if (!BuffUtility.TryGetBuff(Core.EntityManager, ctx.Event.SenderCharacterEntity, Prefabs.AB_Bear_FallAsleep_SleepingIdle_Buff, out var buffEntity))
 		{
-			Buffs.AddBuff(ctx.Event.SenderUserEntity, ctx.Event.SenderCharacterEntity, Prefabs.AB_Bear_FallAsleep_SleepingIdle_Buff, -1, false);
+			Buffs.TryAddBuff(ctx.Event.SenderUserEntity, ctx.Event.SenderCharacterEntity, Prefabs.AB_Bear_FallAsleep_SleepingIdle_Buff, -1, false);
 			ctx.Reply("You are now AFK!");
 		}
 		else

--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -14,26 +14,24 @@ internal static class BloodCommands
 	public static void GiveBloodPotionCommand(ChatCommandContext ctx, BloodType type = BloodType.Frailed, float quality = 100f, int quantity = 1)
 	{
 		quality = Mathf.Clamp(quality, 0, 100);
-		for (var i = 0; i < quantity; i++)
+		var countAdded = Helper.AddBloodPotionToInventory(ctx.Event.SenderCharacterEntity, type, quality, quantity);
+		ctx.Reply($"Received <color=#ff0>{countAdded}</color> Blood Merlot of <color=#ff0>{type}</color> type of <color=#ff0>{quality}</color>% quality");
+		if (countAdded < quantity)
 		{
-			Entity entity = Helper.AddItemToInventory(ctx.Event.SenderCharacterEntity, new PrefabGUID(1223264867), 1);
-
-			if(entity == Entity.Null)
-			{
-				ctx.Reply($"Received <color=#ff0>{i}</color> Blood Merlot of <color=#ff0>{type}</color> type of <color=#ff0>{quality}</color>% quality");
-				ctx.Reply($"Inventory is full, could not add the last <color=#ff0>{quantity - i}</color> Blood Merlot");
-				return;
-			}
-
-			var blood = new StoredBlood()
-			{
-				BloodQuality = quality,
-				PrimaryBloodType = new PrefabGUID((int)type)
-			};
-
-			Core.EntityManager.SetComponentData(entity, blood);
+			ctx.Reply($"Inventory is full, could not add the last <color=#ff0>{quantity - countAdded}</color> Blood Merlot");
 		}
-		ctx.Reply($"Received <color=#ff0>{quantity}</color> Blood Merlot of <color=#ff0>{type}</color> type of <color=#ff0>{quality}</color>% quality");
+	}
+
+	[Command("bloodpotionToAll", null, description: "Gives a potion to all players, with specified Blood Type, Quality, and amount", adminOnly: true)]
+	public static void GiveBloodPotionToAllPlayersCommand(ChatCommandContext ctx, BloodType type = BloodType.Frailed, float quality = 100f, int quantity = 1, bool onlineOnly = false)
+	{
+		quality = Mathf.Clamp(quality, 0, 100);
+		foreach (var characterEntity in Core.Players.GetPlayerCharacters(onlineOnly))
+		{
+			Helper.AddBloodPotionToInventory(characterEntity, type, quality, quantity);
+		}
+		var targetDesc = onlineOnly ? "all online players" : "all players";
+		ctx.Reply($"Gave to {targetDesc}: <color=#ff0>{quantity}</color> Blood Merlot of <color=#ff0>{type}</color> type of <color=#ff0>{quality}</color>% quality");
 	}
 
 	[Command("bloodpotionmix", "bpm", description: "Creates a Potion with two specified Blood Types, Qualities, secondary trait option and amount", adminOnly: true)]

--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -41,7 +41,7 @@ internal static class BloodCommands
 		secondaryQuality = Mathf.Clamp(secondaryQuality, 0, 100);
 		secondaryTrait = Mathf.Clamp(secondaryTrait, 1, 3);
 		var countAdded = Helper.AddBloodMerlotMixToInventory(ctx.Event.SenderCharacterEntity, primaryType, primaryQuality, secondaryType, secondaryQuality, secondaryTrait, quantity);
-		ctx.Reply($"Received <color=#ff0>{quantity}</color> Blood Merlot of <color=#ff0>{primaryType}</color> type of <color=#ff0>{primaryQuality}</color>% quality " +
+		ctx.Reply($"Received <color=#ff0>{countAdded}</color> Blood Merlot of <color=#ff0>{primaryType}</color> type of <color=#ff0>{primaryQuality}</color>% quality " +
 				  $"with secondary <color=#ff0>{secondaryType}</color> type of <color=#ff0>{secondaryQuality}</color>% quality and trait option {secondaryTrait}");
 		if (countAdded < quantity)
 		{

--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -9,7 +9,7 @@ namespace KindredCommands.Commands;
 
 internal static class BloodCommands
 {
-	
+
 	[Command("bloodpotion", "bp", description: "Creates a Potion with specified Blood Type, Quality, and amount", adminOnly: true)]
 	public static void GiveBloodPotionCommand(ChatCommandContext ctx, BloodType type = BloodType.Frailed, float quality = 100f, int quantity = 1)
 	{
@@ -35,39 +35,32 @@ internal static class BloodCommands
 	}
 
 	[Command("bloodpotionmix", "bpm", description: "Creates a Potion with two specified Blood Types, Qualities, secondary trait option and amount", adminOnly: true)]
-	public static void GiveBloodMerlotCommand(ChatCommandContext ctx, BloodType primaryType = BloodType.Frailed, float primaryQuality = 100f, BloodType secondaryType = BloodType.Frailed, float secondaryQuality=100f, int secondaryTrait=1, int quantity = 1)
+	public static void GiveBloodMerlotCommand(ChatCommandContext ctx, BloodType primaryType = BloodType.Frailed, float primaryQuality = 100f, BloodType secondaryType = BloodType.Frailed, float secondaryQuality = 100f, int secondaryTrait = 1, int quantity = 1)
 	{
 		primaryQuality = Mathf.Clamp(primaryQuality, 0, 100);
 		secondaryQuality = Mathf.Clamp(secondaryQuality, 0, 100);
 		secondaryTrait = Mathf.Clamp(secondaryTrait, 1, 3);
-		for (var i = 0; i < quantity; i++)
-		{
-			Entity entity = Helper.AddItemToInventory(ctx.Event.SenderCharacterEntity, new PrefabGUID(1223264867), 1);
-
-			if (entity == Entity.Null)
-			{
-				ctx.Reply($"Received <color=#ff0>{i}</color> Blood Merlot of <color=#ff0>{primaryType}</color> type of <color=#ff0>{primaryQuality}</color>% quality "+
-					      $"with secondary <color=#ff0>{secondaryType}</color> type of <color=#ff0>{secondaryQuality}</color>% quality and trait option {secondaryTrait}");
-				ctx.Reply($"Inventory is full, could not add the last <color=#ff0>{quantity - i}</color> Blood Merlot");
-				return;
-			}
-
-			var blood = new StoredBlood()
-			{
-				BloodQuality = primaryQuality,
-				PrimaryBloodType = new PrefabGUID((int)primaryType),
-				SecondaryBlood = new()
-				{
-					Quality = secondaryQuality,
-					Type = new PrefabGUID((int)secondaryType),
-					BuffIndex = (byte)(secondaryTrait - 1)
-				}
-			};
-
-			Core.EntityManager.SetComponentData(entity, blood);
-		}
-
+		var countAdded = Helper.AddBloodMerlotMixToInventory(ctx.Event.SenderCharacterEntity, primaryType, primaryQuality, secondaryType, secondaryQuality, secondaryTrait, quantity);
 		ctx.Reply($"Received <color=#ff0>{quantity}</color> Blood Merlot of <color=#ff0>{primaryType}</color> type of <color=#ff0>{primaryQuality}</color>% quality " +
+				  $"with secondary <color=#ff0>{secondaryType}</color> type of <color=#ff0>{secondaryQuality}</color>% quality and trait option {secondaryTrait}");
+		if (countAdded < quantity)
+		{
+			ctx.Reply($"Inventory is full, could not add the last <color=#ff0>{quantity - countAdded}</color> Blood Merlot");
+		}
+	}
+
+	[Command("bloodpotionmixToAll", null, description: "Gives a potion to all players, with two specified Blood Types, Qualities, secondary trait option and amount", adminOnly: true)]
+	public static void GiveBloodMerlotToAllPlayersCommand(ChatCommandContext ctx, BloodType primaryType = BloodType.Frailed, float primaryQuality = 100f, BloodType secondaryType = BloodType.Frailed, float secondaryQuality = 100f, int secondaryTrait = 1, int quantity = 1, bool onlineOnly = false)
+	{
+		primaryQuality = Mathf.Clamp(primaryQuality, 0, 100);
+		secondaryQuality = Mathf.Clamp(secondaryQuality, 0, 100);
+		secondaryTrait = Mathf.Clamp(secondaryTrait, 1, 3);
+		foreach (var characterEntity in Core.Players.GetPlayerCharacters(onlineOnly))
+		{
+			Helper.AddBloodMerlotMixToInventory(characterEntity, primaryType, primaryQuality, secondaryType, secondaryQuality, secondaryTrait, quantity);
+		}
+		var targetDesc = onlineOnly ? "all online players" : "all players";
+		ctx.Reply($"Gave to {targetDesc}: <color=#ff0>{quantity}</color> Blood Merlot of <color=#ff0>{primaryType}</color> type of <color=#ff0>{primaryQuality}</color>% quality " +
 				  $"with secondary <color=#ff0>{secondaryType}</color> type of <color=#ff0>{secondaryQuality}</color>% quality and trait option {secondaryTrait}");
 	}
 }

--- a/Commands/BuffCommand.cs
+++ b/Commands/BuffCommand.cs
@@ -41,7 +41,7 @@ internal class BuffCommands
 		var userEntity = player?.Value.UserEntity ?? ctx.Event.SenderUserEntity;
 		var charEntity = player?.Value.CharEntity ?? ctx.Event.SenderCharacterEntity;
 
-		Buffs.TryAddBuff(userEntity, charEntity, buff.Prefab, duration, immortal);
+		Buffs.TryAddOrUpdateBuff(userEntity, charEntity, buff.Prefab, duration, immortal);
 		ctx.Reply($"Applied the buff {buff.Name} to {userEntity.Read<User>().CharacterName}");
 	}
 
@@ -55,7 +55,7 @@ internal class BuffCommands
 			totalCount++;
 			try
 			{
-				Buffs.TryAddBuff(playerData.UserEntity, playerData.CharEntity, buff.Prefab, duration, immortal);
+				Buffs.TryAddOrUpdateBuff(playerData.UserEntity, playerData.CharEntity, buff.Prefab, duration, immortal);
 				successCount++;
 			}
 			catch (Exception ex)

--- a/Commands/BuffCommand.cs
+++ b/Commands/BuffCommand.cs
@@ -41,7 +41,7 @@ internal class BuffCommands
 		var userEntity = player?.Value.UserEntity ?? ctx.Event.SenderUserEntity;
 		var charEntity = player?.Value.CharEntity ?? ctx.Event.SenderCharacterEntity;
 
-		Buffs.AddBuff(userEntity, charEntity, buff.Prefab, duration, immortal);
+		Buffs.TryAddBuff(userEntity, charEntity, buff.Prefab, duration, immortal);
 		ctx.Reply($"Applied the buff {buff.Name} to {userEntity.Read<User>().CharacterName}");
 	}
 
@@ -55,7 +55,7 @@ internal class BuffCommands
 			totalCount++;
 			try
 			{
-				Buffs.AddBuff(playerData.UserEntity, playerData.CharEntity, buff.Prefab, duration, immortal);
+				Buffs.TryAddBuff(playerData.UserEntity, playerData.CharEntity, buff.Prefab, duration, immortal);
 				successCount++;
 			}
 			catch (Exception ex)

--- a/Commands/BuffCommand.cs
+++ b/Commands/BuffCommand.cs
@@ -45,12 +45,54 @@ internal class BuffCommands
 		ctx.Reply($"Applied the buff {buff.Name} to {userEntity.Read<User>().CharacterName}");
 	}
 
+	[Command("buffToAll", "buffAll", adminOnly: true)]
+	public static void BuffToAllOnlinePlayersCommand(ChatCommandContext ctx, BuffInput buff, int duration = 0, bool immortal = false)
+	{
+		int totalCount = 0;
+		int successCount = 0;
+		foreach (var playerData in Core.Players.FindPlayers(onlineOnly: true, requiresCharacter: true))
+		{
+			totalCount++;
+			try
+			{
+				Buffs.AddBuff(playerData.UserEntity, playerData.CharEntity, buff.Prefab, duration, immortal);
+				successCount++;
+			}
+			catch (Exception ex)
+			{
+				Core.Log.LogError(ex);
+			}
+		}
+		ctx.Reply($"Applied the buff {buff.Name} to {successCount}/{totalCount} online players.");
+	}
+
 	[Command("debuff", adminOnly: true)]
 	public static void DebuffCommand(ChatCommandContext ctx, BuffInput buff, OnlinePlayer player = null)
 	{
 		var targetEntity = (Entity)(player?.Value.CharEntity ?? ctx.Event.SenderCharacterEntity);
 		Buffs.RemoveBuff(targetEntity, buff.Prefab);
 		ctx.Reply($"Removed the buff {buff.Name} from {targetEntity.Read<PlayerCharacter>().Name}");
+	}
+
+	[Command("debuffToAll", "debuffAll", adminOnly: true)]
+	public static void DebuffToAllPlayersCommand(ChatCommandContext ctx, BuffInput buff)
+	{
+		int totalCount = 0;
+		int successCount = 0;
+		foreach (var characterEntity in Core.Players.GetPlayerCharacters(onlineOnly: false))
+		{
+			totalCount++;
+			try
+			{
+				Buffs.RemoveBuff(characterEntity, buff.Prefab);
+				successCount++;
+			}
+			catch (Exception ex)
+			{
+				Core.Log.LogError(ex);
+			}
+		}
+		ctx.Reply($"Removed the buff {buff.Name} from {successCount}/{totalCount} players.");
 	}
 
 	[Command("listbuffs", description: "Lists the buffs a player has", adminOnly: true)]

--- a/Commands/GiveItemCommands.cs
+++ b/Commands/GiveItemCommands.cs
@@ -14,4 +14,17 @@ internal class GiveItemCommands
 		var name = prefabSys._PrefabLookupMap.GetName(item.Value);
 		ctx.Reply($"Gave {quantity} {name}");
 	}
+
+	[Command("giveToAll", null, "<Prefab GUID or name> [quantity=1] [onlineOnly=false]", "Gives the specified item to all players", adminOnly: true)]
+	public static void GiveItemToAllPlayers(ChatCommandContext ctx, ItemParameter item, int quantity = 1, bool onlineOnly = false)
+	{
+		foreach (var characterEntity in Core.Players.GetPlayerCharacters(onlineOnly))
+		{
+			Helper.AddItemToInventory(characterEntity, item.Value, quantity);
+		}		
+		var prefabSys = Core.Server.GetExistingSystemManaged<PrefabCollectionSystem>();
+		var name = prefabSys._PrefabLookupMap.GetName(item.Value);
+		var targetDesc = onlineOnly ? "all online players" : "all players";
+		ctx.Reply($"Gave {quantity} {name} to {targetDesc}");
+	}
 }

--- a/Commands/GodCommands.cs
+++ b/Commands/GodCommands.cs
@@ -77,7 +77,7 @@ internal class GodCommands
 		else
 		{
 
-			Buffs.AddBuff(userEntity, charEntity, Prefabs.Admin_Observe_Invisible_Buff, -1);
+			Buffs.TryAddBuff(userEntity, charEntity, Prefabs.Admin_Observe_Invisible_Buff, -1);
 			positionBeforeSpectate.Add(name.ToString(), charEntity.Read<Translation>().Value);
 			ctx.Reply($"<color=yellow>Spectate</color> added to <color=white>{name}</color>");
 		}

--- a/Commands/PlayerCommands.cs
+++ b/Commands/PlayerCommands.cs
@@ -430,7 +430,7 @@ public static class PlayerCommands
 	[Command("staydown", description: "Downs the target player until they get revived- respawns will not get them up.", adminOnly: true)]
 	public static void PermDownPlayer(ChatCommandContext ctx, FoundPlayer player)
 	{
-		Buffs.AddBuff(player.Value.UserEntity, player.Value.CharEntity, new PrefabGUID(-1992158531), -1, true);
+		Buffs.TryAddBuff(player.Value.UserEntity, player.Value.CharEntity, new PrefabGUID(-1992158531), -1, true);
 		ctx.Reply($"Downed {player.Value.CharacterName}");
 	}
 

--- a/Commands/SpawnNpcCommands.cs
+++ b/Commands/SpawnNpcCommands.cs
@@ -54,7 +54,7 @@ internal static class SpawnCommands
 			{
 				if (level > 0)
 				{
-					Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.BoostedBuff1, -1, true);
+					Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.BoostedBuff1, -1, true);
 					if (BuffUtility.TryGetBuff(Core.EntityManager, e, Prefabs.BoostedBuff1, out var buffEntity))
 					{
 						buffEntity.Remove<SpawnStructure_WeakenState_DataShared>();
@@ -111,35 +111,35 @@ internal static class SpawnCommands
 				switch (type)
 				{
 					case BloodType.Brute:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Brute, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Brute, -1, true);
 						break;
 					case BloodType.Creature:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Creature, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Creature, -1, true);
 						break;
 					case BloodType.Draculin:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Draculin, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Draculin, -1, true);
 						break;
 					case BloodType.Mutant:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Mutant, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Mutant, -1, true);
 						break;
 					case BloodType.Rogue:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Rogue, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Rogue, -1, true);
 						break;
 					case BloodType.Scholar:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Scholar, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Scholar, -1, true);
 						break;
 					case BloodType.Warrior:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Warrior, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Warrior, -1, true);
 						break;
 					case BloodType.Worker:
-						Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Worker, -1, true);
+						Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.AB_BloodQualityUnitBuff_Worker, -1, true);
 						break;
 				}
 			}
 
 			if (level > 0)
 			{
-				Buffs.AddBuff(ctx.Event.SenderUserEntity, e, Prefabs.BoostedBuff1, -1, true);
+				Buffs.TryAddBuff(ctx.Event.SenderUserEntity, e, Prefabs.BoostedBuff1, -1, true);
 				if (BuffUtility.TryGetBuff(Core.EntityManager, e, Prefabs.BoostedBuff1, out var buffEntity))
 				{
 					buffEntity.Remove<SpawnStructure_WeakenState_DataShared>();

--- a/Helper.cs
+++ b/Helper.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Il2CppInterop.Runtime;
 using Il2CppSystem;
 using KindredCommands.Data;
+using KindredCommands.Models;
 using ProjectM;
 using ProjectM.CastleBuilding;
 using ProjectM.Gameplay.Clan;
@@ -65,6 +66,29 @@ internal static partial class Helper
 			Core.LogException(e);
 		}
 		return new Entity();
+	}
+
+	public static int AddBloodPotionToInventory(Entity recipient, BloodType type = BloodType.Frailed, float quality = 100f, int quantity = 1)
+	{
+		var countAdded = 0;
+		while (countAdded < quantity)
+		{
+			Entity addedItemEntity = AddItemToInventory(recipient, new PrefabGUID(1223264867), 1);
+			if (addedItemEntity == Entity.Null)
+			{
+				break;
+			}
+
+			var blood = new StoredBlood()
+			{
+				BloodQuality = quality,
+				PrimaryBloodType = new PrefabGUID((int)type)
+			};
+
+			Core.EntityManager.SetComponentData(addedItemEntity, blood);
+			countAdded++;
+		}
+		return countAdded;
 	}
 
 	public static NativeArray<Entity> GetEntitiesByComponentType<T1>(bool includeAll = false, bool includeDisabled = false, bool includeSpawn = false, bool includePrefab = false, bool includeDestroyed = false)

--- a/Helper.cs
+++ b/Helper.cs
@@ -91,6 +91,35 @@ internal static partial class Helper
 		return countAdded;
 	}
 
+	public static int AddBloodMerlotMixToInventory(Entity recipient, BloodType primaryType = BloodType.Frailed, float primaryQuality = 100f, BloodType secondaryType = BloodType.Frailed, float secondaryQuality = 100f, int secondaryTrait = 1, int quantity = 1)
+	{
+		var countAdded = 0;
+		while (countAdded < quantity)
+		{
+			Entity addedItemEntity = AddItemToInventory(recipient, new PrefabGUID(1223264867), 1);
+			if (addedItemEntity == Entity.Null)
+			{
+				break;
+			}
+
+			var blood = new StoredBlood()
+			{
+				BloodQuality = primaryQuality,
+				PrimaryBloodType = new PrefabGUID((int)primaryType),
+				SecondaryBlood = new()
+				{
+					Quality = secondaryQuality,
+					Type = new PrefabGUID((int)secondaryType),
+					BuffIndex = (byte)(secondaryTrait - 1)
+				}
+			};
+
+			Core.EntityManager.SetComponentData(addedItemEntity, blood);
+			countAdded++;
+		}
+		return countAdded;
+	}
+
 	public static NativeArray<Entity> GetEntitiesByComponentType<T1>(bool includeAll = false, bool includeDisabled = false, bool includeSpawn = false, bool includePrefab = false, bool includeDestroyed = false)
 	{
 		EntityQueryOptions options = EntityQueryOptions.Default;

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Feel free to reach out to me on Discord (odjit) if you have any questions or nee
   - will give Merlot of specified type and quality. You can also specify an amount
   - Example: *.bp creature 100 1*
   - Shortcut: *.bp*
+- `.bloodpotionToAll (Bloodtype) (Quality) (Amount) (onlineOnly: true/false)`
+  - will give Merlot of specified type and quality to all players. You can also specify an amount. onlineOnly can be used to only give to online players.
+  - Example: *.bloodpotionToAll creature 100 1 false*
 - `.bloodpotionmix (PrimaryType) (PrimaryQuality) (SecondaryType) (SecondaryQuality) (SecondaryTrait) (Quantity)`
   - will give Merlot with two specified Blood Types, Qualities, secondary trait option and amount
   - Example: *.bpm warrior 100 creature 100 1 5*
@@ -152,7 +155,7 @@ Feel free to reach out to me on Discord (odjit) if you have any questions or nee
   - Shortcut: *.g*
 - `.giveToAll (Item prefab name) (amount) (onlineOnly: true/false)`
   - will give an item to all players. onlineOnly can be used to only give to online players.
-  - Example: *.giveAll Headgear_arcmageCrown 1 false*
+  - Example: *.giveToAll Headgear_arcmageCrown 1 false*
 - `.search item (name) (page #)`
   - Will respond with the item prefab name needed.
   - Example: *.search item arcmage*

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Feel free to reach out to me on Discord (odjit) if you have any questions or nee
 - `.give (Item prefab name) (amount)`			
   - Example: *.give Headgear_arcmageCrown 1*
   - Shortcut: *.g*
+- `.giveToAll (Item prefab name) (amount) (onlineOnly: true/false)`
+  - will give an item to all players. onlineOnly can be used to only give to online players.
+  - Example: *.giveAll Headgear_arcmageCrown 1 false*
 - `.search item (name) (page #)`
   - Will respond with the item prefab name needed.
   - Example: *.search item arcmage*

--- a/README.md
+++ b/README.md
@@ -143,13 +143,16 @@ Feel free to reach out to me on Discord (odjit) if you have any questions or nee
   - will give Merlot of specified type and quality. You can also specify an amount
   - Example: *.bp creature 100 1*
   - Shortcut: *.bp*
-- `.bloodpotionToAll (Bloodtype) (Quality) (Amount) (onlineOnly: true/false)`
-  - will give Merlot of specified type and quality to all players. You can also specify an amount. onlineOnly can be used to only give to online players.
+- `.bloodpotionToAll (Bloodtype) (Quality) (Amount) (OnlineOnly: true/false)`
+  - will give Merlot of specified type and quality to all players. You can also specify an amount. OnlineOnly can be used to only give to online players.
   - Example: *.bloodpotionToAll creature 100 1 false*
 - `.bloodpotionmix (PrimaryType) (PrimaryQuality) (SecondaryType) (SecondaryQuality) (SecondaryTrait) (Quantity)`
   - will give Merlot with two specified Blood Types, Qualities, secondary trait option and amount
   - Example: *.bpm warrior 100 creature 100 1 5*
   - Shortcut: *.bpm*
+- `.bloodpotionmixToAll (PrimaryType) (PrimaryQuality) (SecondaryType) (SecondaryQuality) (SecondaryTrait) (Quantity) (OnlineOnly: true/false)`
+  - will give Merlot to all players, with two specified Blood Types, Qualities, secondary trait option and amount. OnlineOnly can be used to only give to online players.
+  - Example: *.bloodpotionmixToAll warrior 100 creature 100 1 5 false*
 - `.give (Item prefab name) (amount)`			
   - Example: *.give Headgear_arcmageCrown 1*
   - Shortcut: *.g*

--- a/README.md
+++ b/README.md
@@ -199,9 +199,15 @@ Feel free to reach out to me on Discord (odjit) if you have any questions or nee
 - `.buff (Buff GUID) (Player) (Duration) (Immortal)`
   - Adds a buff to a player named, or the user if no one is named. Duration 0 for default behavior, -1 for eternal, or whatever number of seconds. Immortal true/false for it to last after death.	Be careful, as some buffs can break things. Always test on a test server first.
   - Example: *.buff 476186894 Bob*
+- `.buffToAll (BuffGUID) (Duration) (Immortal)`
+  - Same as .buff, but applies the buff to all online players.
+  - Example: `.buffToAll -1591883586 7200`
 - `.debuff (Buff GUID) (Player)`
   - Removes a buff from a player named, or the user if no one is named. Will work on offline players.
   - Example: *.debuff 476186894 Bob*
+- `.debuffToAll (BuffGUID)`
+  - Same as .debuff, but removes the buff from all players.
+  - Example: `.debuffToAll -1591883586`
 - `.listbuffs (Player)`
   - will show all buffs on a player																								
   - Example: *.listbuffs Bob*

--- a/Services/BoostedPlayerService.cs
+++ b/Services/BoostedPlayerService.cs
@@ -87,7 +87,7 @@ namespace KindredCommands.Services
 
 			if (immaterialPlayers.Contains(charEntity))
 			{
-				Buffs.AddBuff(userEntity, charEntity, Prefabs.AB_Blood_BloodRite_Immaterial, -1, true);
+				Buffs.TryAddBuff(userEntity, charEntity, Prefabs.AB_Blood_BloodRite_Immaterial, -1, true);
 				if (BuffUtility.TryGetBuff(Core.EntityManager, charEntity, Prefabs.AB_Blood_BloodRite_Immaterial, out Entity immaterialBuffEntity))
 				{
 					var modifyMovementSpeedBuff = immaterialBuffEntity.Read<ModifyMovementSpeedBuff>();
@@ -102,7 +102,7 @@ namespace KindredCommands.Services
 
 			if (shroudedPlayers.Contains(charEntity))
 			{
-				Buffs.AddBuff(userEntity, charEntity, Prefabs.EquipBuff_ShroudOfTheForest, -1, true);
+				Buffs.TryAddBuff(userEntity, charEntity, Prefabs.EquipBuff_ShroudOfTheForest, -1, true);
 			}
 			else
 			{
@@ -123,8 +123,8 @@ namespace KindredCommands.Services
 			while (BuffUtility.HasBuff(Core.EntityManager, charEntity, Prefabs.BoostedBuff2))
 				yield return null;
 
-			Buffs.AddBuff(userEntity, charEntity, Prefabs.BoostedBuff1, -1, true);
-			Buffs.AddBuff(userEntity, charEntity, Prefabs.BoostedBuff2, -1, true);
+			Buffs.TryAddBuff(userEntity, charEntity, Prefabs.BoostedBuff1, -1, true);
+			Buffs.TryAddBuff(userEntity, charEntity, Prefabs.BoostedBuff2, -1, true);
 
 			if (BuffUtility.TryGetBuff(Core.EntityManager, charEntity, Prefabs.BoostedBuff1, out var buffEntity))
 			{
@@ -422,7 +422,7 @@ namespace KindredCommands.Services
 			while(BuffUtility.HasBuff(Core.EntityManager, charEntity, buffPrefab))
 				yield return null;
 			if(IsPlayerShrouded(charEntity))
-				Buffs.AddBuff(charEntity.Read<PlayerCharacter>().UserEntity, charEntity, buffPrefab, -1, true);
+				Buffs.TryAddBuff(charEntity.Read<PlayerCharacter>().UserEntity, charEntity, buffPrefab, -1, true);
 		}
 
 		public bool IsPlayerShrouded(Entity charEntity)

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -110,6 +110,25 @@ internal class PlayerService
 
 		return true;
 	}
+
+	public IEnumerable<Entity> GetPlayerCharacters(bool onlineOnly)
+	{
+		var entityQueryBuilder = new EntityQueryBuilder(Allocator.Temp)
+			.AddAll(new(Il2CppType.Of<User>(), ComponentType.AccessMode.ReadOnly));
+		var query = Core.EntityManager.CreateEntityQuery(ref entityQueryBuilder);
+		var userDatas = query.ToComponentDataArray<User>(Allocator.Temp);
+		foreach (var user in userDatas)
+		{
+			bool meetsOnlineCriteria = !onlineOnly || user.IsConnected;
+			bool hasCharacter = !user.LocalCharacter._Entity.Equals(Entity.Null);			
+			if (meetsOnlineCriteria && hasCharacter)
+			{
+				yield return user.LocalCharacter._Entity;
+			}
+		}
+		userDatas.Dispose();
+	}
+
 	public static IEnumerable<Entity> GetUsersOnline()
 	{
 		var entityQueryBuilder = new EntityQueryBuilder(Allocator.Temp)


### PR DESCRIPTION
Added commands to give things to all players.
- `.giveToAll` - same as `.give`, but gives to all players
- `.bloodpotionToAll` - same as `.bloodpotion`, but gives to all players
- `.bloodpotionmixToAll` - same as `.bloodptionmix`, but gives to all players

Each one has an option to only give to online players.

Also added commands to buff/debuff all players.
- `.buffToAll` - same as `.buff`, but gives buffs to all *online* players.
- `.debuffToAll` - same as `.debuff`, but removes buffs from all players.


Additionally changed the behaviour of `.buff` to update a buff if it already exists.
- Duration will be reset (e.g. if the buff has 10 minutes left and desired duration is set to 2 hours, the remaining timer (`duration - age`) will become 2 hours.
- Buff persistence through death (the "immortal" option) will be updated.